### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Description
 
+[![Project Status: Unsupported](https://www.repostatus.org/badges/latest/unsupported.svg)](https://www.repostatus.org/#unsupported)
+
+**This project is archived for future reference, but no new work is expected in this repository.**
+
 The Dockerfile in this repository creates an image containing a freshly
 cloned copy of workflow.pacta. It also installs the relevant PACTA R packages 
 that it depends on.


### PR DESCRIPTION
This PR marks the repository as archived in the README by adding the unsupported badge and archive notice under the main header.